### PR TITLE
fix: robust CORS origin merging for Vercel preview

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -12,9 +12,19 @@ const bodyParser = require('body-parser');
 const app = express();
 const cors = require('cors');
 
-const allowedOrigins = process.env.ALLOWED_ORIGINS
+const defaultOrigins = [
+  'http://localhost:5173',
+  'https://localhost:5173',
+  'http://localhost:4200',
+  'https://aerobook.app',
+  'https://preview.aerobook.app'
+];
+
+const envOrigins = process.env.ALLOWED_ORIGINS
   ? process.env.ALLOWED_ORIGINS.split(',').map(o => o.trim())
-  : ['http://localhost:5173', 'https://localhost:5173', 'http://localhost:4200', 'https://aerobook.app', 'https://preview.aerobook.app'];
+  : [];
+
+const allowedOrigins = [...new Set([...defaultOrigins, ...envOrigins])];
 
 function isOriginAllowed(origin) {
   // Exact match


### PR DESCRIPTION
This PR updates the CORS logic to always include a baseline of required origins (like the Vercel preview domain) even if the  environment variable is set, preventing unintentional overrides.