### PR TITLE
feat: optional welcome email during registration (Issue #37)

### DIFF
--- a/src/controllers/memberController.js
+++ b/src/controllers/memberController.js
@@ -26,7 +26,7 @@ const getMemberById = async (req, res) => {
 };
 
 const createMember = async (req, res) => {
-    const { member_number, first_name, last_name, email, phone, password, role } = req.body;
+    const { member_number, first_name, last_name, email, phone, password, role, skip_welcome_email } = req.body;
 
     // Validate required fields
     if (!first_name || !last_name || !email || !password) {
@@ -53,10 +53,14 @@ const createMember = async (req, res) => {
 
         const newMember = result.rows[0];
 
-        console.log('Attempting to send welcome email to:', newMember.email);
-        sendWelcomeEmail(newMember)
-            .then(() => console.log('Welcome email sent successfully to:', newMember.email))
-            .catch((err) => console.error('Failed to send welcome email:', err.message));
+        if (!skip_welcome_email) {
+            console.log('Attempting to send welcome email to:', newMember.email);
+            sendWelcomeEmail(newMember)
+                .then(() => console.log('Welcome email sent successfully to:', newMember.email))
+                .catch((err) => console.error('Failed to send welcome email:', err.message));
+        } else {
+            console.log('Skipping welcome email for:', newMember.email);
+        }
 
         res.status(201).json({
             id: newMember.id,

--- a/test/members.test.js
+++ b/test/members.test.js
@@ -110,6 +110,16 @@ describe('Members endpoint', () => {
     expect(mailOptions.html).toMatch(/reset-password/i);
   });
 
+  test('POST /api/members does NOT send welcome email if skip_welcome_email is true', async () => {
+    mockSend.mockClear();
+    const payload = { member_number: 'M-102', first_name: 'NoEmail', last_name: 'User', email: 'noemail@example.com', password: 'pass', skip_welcome_email: true };
+    const res = await httpRequest(port, '/api/members', 'POST', payload, { Authorization: 'Bearer faketoken' });
+    expect(res.statusCode).toBe(201);
+    // Allow time for any potential background tasks
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
   test('GET /api/members returns list when authorized', async () => {
     const headers = { Authorization: 'Bearer faketoken' };
     const res = await httpRequest(port, '/api/members', 'GET', null, headers);


### PR DESCRIPTION
This PR allows administrators to choose whether to send a welcome email when creating a new member, by adding a  flag to the registration endpoint.