### PR TITLE
feat: backend validation for future reservations

### DIFF
--- a/src/controllers/reservationsController.js
+++ b/src/controllers/reservationsController.js
@@ -71,6 +71,11 @@ const createReservation = async (req, res) => {
     member_id = req.user.id;
   }
 
+  // Ensure start_time is not in the past
+  if (new Date(start_time) < new Date()) {
+    return res.status(400).json({ error: 'Reservations cannot be made in the past' });
+  }
+
   // Check if aircraft is available
   const aircraftCheck = await pool.query('SELECT is_available FROM aircraft WHERE id = $1', [aircraft_id]);
   if (aircraftCheck.rows.length === 0) {
@@ -127,6 +132,11 @@ const updateReservation = async (req, res) => {
     const newAircraftId = aircraft_id || current.aircraft_id;
     const newStartTime = start_time || current.start_time;
     const newEndTime = end_time || current.end_time;
+
+    // Ensure new start_time is not in the past
+    if (new Date(newStartTime) < new Date()) {
+      return res.status(400).json({ error: 'Reservations cannot be moved to the past' });
+    }
 
     // Check if new aircraft is available
     if (aircraft_id) {

--- a/test/reservations.test.js
+++ b/test/reservations.test.js
@@ -40,7 +40,7 @@ jest.mock('pg', () => {
 
       // Conflict check
       if (lt.includes('select id from reservations')) {
-        if (params && params[0] === 1 && params[1] === '2026-01-01T10:00:00Z') {
+        if (params && params[0] === 1 && params[1] === '2027-01-01T10:00:00Z') {
           return Promise.resolve({ rows: [{ id: 99 }] });
         }
         return Promise.resolve({ rows: [] });
@@ -158,8 +158,21 @@ describe('Reservations endpoint', () => {
     expect(res.body).toHaveProperty('notes', 'Test reservation');
   });
 
+  test('POST /api/reservations fails for past start_time', async () => {
+    const payload = {
+      member_id: 1,
+      aircraft_id: 3,
+      start_time: '2020-01-01T09:00:00Z',
+      end_time: '2020-01-01T10:00:00Z',
+      notes: 'Past reservation'
+    };
+    const res = await httpRequest(port, '/api/reservations', 'POST', payload, { Authorization: 'Bearer faketoken' });
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toHaveProperty('error', 'Reservations cannot be made in the past');
+  });
+
   test('POST /api/reservations returns 409 on conflict', async () => {
-    const payload = { member_id: 1, aircraft_id: 1, start_time: '2026-01-01T10:00:00Z', end_time: '2026-01-01T11:00:00Z' };
+    const payload = { member_id: 1, aircraft_id: 1, start_time: '2027-01-01T10:00:00Z', end_time: '2027-01-01T11:00:00Z' };
     const res = await httpRequest(port, '/api/reservations', 'POST', payload, { Authorization: 'Bearer faketoken' });
     expect(res.statusCode).toBe(409);
     expect(res.body).toHaveProperty('error');


### PR DESCRIPTION
This PR adds backend validation to ensure all new and updated reservations have a start time in the future, complementing the frontend restrictions for issue #47.