### PR TITLE
feat: #55 - add needs_log filter to reservations API

### DIFF
--- a/src/controllers/reservationsController.js
+++ b/src/controllers/reservationsController.js
@@ -1,7 +1,7 @@
 const pool = require('../config/database');
 
 const getReservations = async (req, res) => {
-  const { member_id, aircraft_id, status, start_date, end_date } = req.query;
+  const { member_id, aircraft_id, status, start_date, end_date, needs_log } = req.query;
   let query = `
     SELECT r.*,
            m.first_name || ' ' || m.last_name as member_name,
@@ -9,6 +9,7 @@ const getReservations = async (req, res) => {
     FROM reservations r
     JOIN members m ON r.member_id = m.id
     JOIN aircraft a ON r.aircraft_id = a.id
+    LEFT JOIN flight_logs fl ON r.id = fl.reservation_id
     WHERE 1=1
   `;
   const params = [];
@@ -37,6 +38,9 @@ const getReservations = async (req, res) => {
     query += ` AND r.end_time <= $${paramCount}`;
     params.push(end_date);
     paramCount++;
+  }
+  if (needs_log === 'true') {
+    query += ` AND r.status NOT IN ('cancelled', 'completed') AND r.end_time < NOW() AND fl.id IS NULL`;
   }
   query += ' ORDER BY r.start_time DESC';
   const result = await pool.query(query, params);


### PR DESCRIPTION
Adds a query parameter to filter for past reservations that lack associated flight logs, enabling the frontend prompt feature.