### PR TITLE
docs: update .env.example with modern npm build vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,10 @@ RESEND_FROM=YourApp <noreply@your-domain.com>
 JWT_SECRET=your-jwt-secret-here-generate-with-openssl-rand-base64-32
 RESET_TOKEN_SECRET=your-reset-token-secret-generate-with-openssl-rand-base64-32
 
+# Build Configuration (Railway)
+NPM_CONFIG_PRODUCTION=false
+NPM_CONFIG_OMIT=dev
+
 # ===========================================
 # Optional Configuration
 # ===========================================


### PR DESCRIPTION
Adds NPM_CONFIG_PRODUCTION and NPM_CONFIG_OMIT to the example environment file to help developers avoid deprecation warnings on Railway.