### PR TITLE
fix: specify service in railway sync script

### DIFF
--- a/scripts/railway/setup-env-vars.sh
+++ b/scripts/railway/setup-env-vars.sh
@@ -57,7 +57,7 @@ while IFS= read -r line || [ -n "$line" ]; do
     
     if [ -n "$key" ] && [ -n "$value" ]; then
         echo "Setting $key..."
-        railway variables set "$key"="$value"
+        railway variables set --service aerobook-api "$key"="$value"
     fi
 done < "$ENV_FILE"
 


### PR DESCRIPTION
Updates the environment variable sync script to explicitly target the 'aerobook-api' service, preventing 'No service linked' errors during setup.